### PR TITLE
Migrates from react-router-redux to connected-react-router WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "productName": "Rekit",
     "copyright": "Copyright © 2018 ${author}",
     "asar": true,
-    "asarUnpack": ["node_modules"],
+    "asarUnpack": [
+      "node_modules"
+    ],
     "npmRebuild": false,
     "files": [
       "build",
@@ -113,6 +115,7 @@
     "babel-runtime": "6.26.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
+    "connected-react-router": "^5.0.1",
     "cross-env": "^5.2.0",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
@@ -150,7 +153,6 @@
     "react-hot-loader": "^4.0.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
-    "react-router-redux": "5.0.0-alpha.9",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.1",

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,57 +1,57 @@
 /* This is the Root component mainly initializes Redux and React Router. */
 
-import React from 'react'
-import PropTypes from 'prop-types'
-import { Provider } from 'react-redux'
-import { Switch, Route } from 'react-router-dom'
-import { ConnectedRouter } from 'connected-react-router'
-import history from './common/history'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { Switch, Route } from 'react-router-dom';
+import { ConnectedRouter } from 'connected-react-router';
+import history from './common/history';
 
 function renderRouteConfigV3(routes, contextPath) {
   // Resolve route config object in React Router v3.
-  const children = [] // children component list
+  const children = []; // children component list
 
   const renderRoute = (item, routeContextPath) => {
-    let newContextPath
+    let newContextPath;
     if (/^\//.test(item.path)) {
-      newContextPath = item.path
+      newContextPath = item.path;
     } else {
-      newContextPath = `${routeContextPath}/${item.path}`
+      newContextPath = `${routeContextPath}/${item.path}`;
     }
-    newContextPath = newContextPath.replace(/\/+/g, '/')
+    newContextPath = newContextPath.replace(/\/+/g, '/');
     if (item.component && item.childRoutes) {
-      const childRoutes = renderRouteConfigV3(item.childRoutes, newContextPath)
+      const childRoutes = renderRouteConfigV3(item.childRoutes, newContextPath);
       children.push(
         <Route
           key={newContextPath}
           render={props => <item.component {...props}>{childRoutes}</item.component>}
           path={newContextPath}
         />
-      )
+      );
     } else if (item.component) {
-      children.push(<Route key={newContextPath} component={item.component} path={newContextPath} exact />)
+      children.push(<Route key={newContextPath} component={item.component} path={newContextPath} exact />);
     } else if (item.childRoutes) {
-      item.childRoutes.forEach(r => renderRoute(r, newContextPath))
+      item.childRoutes.forEach(r => renderRoute(r, newContextPath));
     }
-  }
+  };
 
-  routes.forEach(item => renderRoute(item, contextPath))
+  routes.forEach(item => renderRoute(item, contextPath));
 
   // Use Switch so that only the first matched route is rendered.
-  return <Switch>{children}</Switch>
+  return <Switch>{children}</Switch>;
 }
 
 export default class Root extends React.Component {
   static propTypes = {
     store: PropTypes.object.isRequired,
     routeConfig: PropTypes.array.isRequired,
-  }
+  };
   render() {
-    const children = renderRouteConfigV3(this.props.routeConfig, '/')
+    const children = renderRouteConfigV3(this.props.routeConfig, '/');
     return (
       <Provider store={this.props.store}>
         <ConnectedRouter history={history}>{children}</ConnectedRouter>
       </Provider>
-    )
+    );
   }
 }

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,57 +1,57 @@
 /* This is the Root component mainly initializes Redux and React Router. */
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Provider } from 'react-redux';
-import { Switch, Route } from 'react-router-dom';
-import { ConnectedRouter } from 'react-router-redux';
-import history from './common/history';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Provider } from 'react-redux'
+import { Switch, Route } from 'react-router-dom'
+import { ConnectedRouter } from 'connected-react-router'
+import history from './common/history'
 
 function renderRouteConfigV3(routes, contextPath) {
   // Resolve route config object in React Router v3.
-  const children = []; // children component list
+  const children = [] // children component list
 
   const renderRoute = (item, routeContextPath) => {
-    let newContextPath;
+    let newContextPath
     if (/^\//.test(item.path)) {
-      newContextPath = item.path;
+      newContextPath = item.path
     } else {
-      newContextPath = `${routeContextPath}/${item.path}`;
+      newContextPath = `${routeContextPath}/${item.path}`
     }
-    newContextPath = newContextPath.replace(/\/+/g, '/');
+    newContextPath = newContextPath.replace(/\/+/g, '/')
     if (item.component && item.childRoutes) {
-      const childRoutes = renderRouteConfigV3(item.childRoutes, newContextPath);
+      const childRoutes = renderRouteConfigV3(item.childRoutes, newContextPath)
       children.push(
         <Route
           key={newContextPath}
           render={props => <item.component {...props}>{childRoutes}</item.component>}
           path={newContextPath}
         />
-      );
+      )
     } else if (item.component) {
-      children.push(<Route key={newContextPath} component={item.component} path={newContextPath} exact />);
+      children.push(<Route key={newContextPath} component={item.component} path={newContextPath} exact />)
     } else if (item.childRoutes) {
-      item.childRoutes.forEach(r => renderRoute(r, newContextPath));
+      item.childRoutes.forEach(r => renderRoute(r, newContextPath))
     }
-  };
+  }
 
-  routes.forEach(item => renderRoute(item, contextPath));
+  routes.forEach(item => renderRoute(item, contextPath))
 
   // Use Switch so that only the first matched route is rendered.
-  return <Switch>{children}</Switch>;
+  return <Switch>{children}</Switch>
 }
 
 export default class Root extends React.Component {
   static propTypes = {
     store: PropTypes.object.isRequired,
     routeConfig: PropTypes.array.isRequired,
-  };
+  }
   render() {
-    const children = renderRouteConfigV3(this.props.routeConfig, '/');
+    const children = renderRouteConfigV3(this.props.routeConfig, '/')
     return (
       <Provider store={this.props.store}>
         <ConnectedRouter history={history}>{children}</ConnectedRouter>
       </Provider>
-    );
+    )
   }
 }

--- a/src/common/configStore.js
+++ b/src/common/configStore.js
@@ -1,44 +1,42 @@
-import { createStore, applyMiddleware, compose } from 'redux';
-import thunk from 'redux-thunk';
-import { routerMiddleware } from 'react-router-redux';
-import history from './history';
-import rootReducer from './rootReducer';
-
-const router = routerMiddleware(history);
+import { createStore, applyMiddleware, compose } from 'redux'
+import thunk from 'redux-thunk'
+import { routerMiddleware } from 'connected-react-router'
+import history from './history'
+import createRootReducer from './rootReducer'
 
 // NOTE: Do not change middleares delaration pattern since rekit plugins may register middlewares to it.
 const middlewares = [
   thunk,
-  router,
-];
+  routerMiddleware(history),
+]
 
-let devToolsExtension = f => f;
+let devToolsExtension = f => f
 
 /* istanbul ignore if  */
 if (process.env.NODE_ENV === 'development') {
-  const { createLogger } = require('redux-logger');
+  const { createLogger } = require('redux-logger')
 
-  const logger = createLogger({ collapsed: true });
-  middlewares.push(logger);
+  const logger = createLogger({ collapsed: true })
+  middlewares.push(logger)
 
   if (window.devToolsExtension) {
-    devToolsExtension = window.devToolsExtension();
+    devToolsExtension = window.devToolsExtension()
   }
 }
 
 export default function configureStore(initialState) {
-  const store = createStore(rootReducer, initialState, compose(
+  const store = createStore(createRootReducer(history), initialState, compose(
     applyMiddleware(...middlewares),
     devToolsExtension
-  ));
+  ))
 
   /* istanbul ignore if  */
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('./rootReducer', () => {
-      const nextRootReducer = require('./rootReducer').default; // eslint-disable-line
-      store.replaceReducer(nextRootReducer);
-    });
+      const nextRootReducer = require('./rootReducer').default // eslint-disable-line
+      store.replaceReducer(nextRootReducer)
+    })
   }
-  return store;
+  return store
 }

--- a/src/common/configStore.js
+++ b/src/common/configStore.js
@@ -1,26 +1,26 @@
-import { createStore, applyMiddleware, compose } from 'redux'
-import thunk from 'redux-thunk'
-import { routerMiddleware } from 'connected-react-router'
-import history from './history'
-import createRootReducer from './rootReducer'
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunk from 'redux-thunk';
+import { routerMiddleware } from 'connected-react-router';
+import history from './history';
+import createRootReducer from './rootReducer';
 
 // NOTE: Do not change middleares delaration pattern since rekit plugins may register middlewares to it.
 const middlewares = [
   thunk,
   routerMiddleware(history),
-]
+];
 
-let devToolsExtension = f => f
+let devToolsExtension = f => f;
 
 /* istanbul ignore if  */
 if (process.env.NODE_ENV === 'development') {
-  const { createLogger } = require('redux-logger')
+  const { createLogger } = require('redux-logger');
 
-  const logger = createLogger({ collapsed: true })
-  middlewares.push(logger)
+  const logger = createLogger({ collapsed: true });
+  middlewares.push(logger);
 
   if (window.devToolsExtension) {
-    devToolsExtension = window.devToolsExtension()
+    devToolsExtension = window.devToolsExtension();
   }
 }
 
@@ -28,15 +28,15 @@ export default function configureStore(initialState) {
   const store = createStore(createRootReducer(history), initialState, compose(
     applyMiddleware(...middlewares),
     devToolsExtension
-  ))
+  ));
 
   /* istanbul ignore if  */
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('./rootReducer', () => {
-      const nextRootReducer = require('./rootReducer').default // eslint-disable-line
-      store.replaceReducer(nextRootReducer)
-    })
+      const nextRootReducer = require('./rootReducer').default; // eslint-disable-line
+      store.replaceReducer(nextRootReducer);
+    });
   }
-  return store
+  return store;
 }

--- a/src/common/rootReducer.js
+++ b/src/common/rootReducer.js
@@ -1,9 +1,9 @@
-import { combineReducers } from 'redux'
-import { connectRouter } from 'connected-react-router'
-import homeReducer from '../features/home/redux/reducer'
-import commonReducer from '../features/common/redux/reducer'
-import examplesReducer from '../features/examples/redux/reducer'
-import newProjectReducer from '../features/new-project/redux/reducer'
+import { combineReducers } from 'redux';
+import { connectRouter } from 'connected-react-router';
+import homeReducer from '../features/home/redux/reducer';
+import commonReducer from '../features/common/redux/reducer';
+import examplesReducer from '../features/examples/redux/reducer';
+import newProjectReducer from '../features/new-project/redux/reducer';
 
 // NOTE 1: DO NOT CHANGE the 'reducerMap' name and the declaration pattern.
 // This is used for Rekit cmds to register new features, remove features, etc.
@@ -15,9 +15,9 @@ const reducerMap = {
   common: commonReducer,
   examples: examplesReducer,
   newProject: newProjectReducer,
-}
+};
 
 export default (history) => combineReducers({
   router: connectRouter(history),
   ...reducerMap
-})
+});

--- a/src/common/rootReducer.js
+++ b/src/common/rootReducer.js
@@ -1,9 +1,9 @@
-import { combineReducers } from 'redux';
-import { routerReducer } from 'react-router-redux';
-import homeReducer from '../features/home/redux/reducer';
-import commonReducer from '../features/common/redux/reducer';
-import examplesReducer from '../features/examples/redux/reducer';
-import newProjectReducer from '../features/new-project/redux/reducer';
+import { combineReducers } from 'redux'
+import { connectRouter } from 'connected-react-router'
+import homeReducer from '../features/home/redux/reducer'
+import commonReducer from '../features/common/redux/reducer'
+import examplesReducer from '../features/examples/redux/reducer'
+import newProjectReducer from '../features/new-project/redux/reducer'
 
 // NOTE 1: DO NOT CHANGE the 'reducerMap' name and the declaration pattern.
 // This is used for Rekit cmds to register new features, remove features, etc.
@@ -11,11 +11,13 @@ import newProjectReducer from '../features/new-project/redux/reducer';
 // So that it's easy for others to understand it and Rekit could manage them.
 
 const reducerMap = {
-  router: routerReducer,
   home: homeReducer,
   common: commonReducer,
   examples: examplesReducer,
   newProject: newProjectReducer,
-};
+}
 
-export default combineReducers(reducerMap);
+export default (history) => combineReducers({
+  router: connectRouter(history),
+  ...reducerMap
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,18 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@sindresorhus/df@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
+  integrity sha1-xptm9S9vzdKHyAffIQMF2694UA0=
+
+"@sindresorhus/df@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-2.1.0.tgz#d208cf27e06f0bb476d14d7deccd7d726e9aa389"
+  integrity sha1-0gjPJ+BvC7R20U197M19cm6ao4k=
+  dependencies:
+    execa "^0.2.2"
+
 "@types/node@*":
   version "10.12.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.11.tgz#715c476c99a5f6898a1ae61caf9825e43c03912e"
@@ -303,7 +315,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.10, argparse@^1.0.7:
+argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
@@ -1683,7 +1695,7 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.2, chokidar@^2.0.4:
+chokidar@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
@@ -1923,7 +1935,7 @@ compressible@~2.0.14:
   dependencies:
     mime-db ">= 1.36.0 < 2"
 
-compression@^1.5.2, compression@^1.7.3:
+compression@^1.5.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
   dependencies:
@@ -1972,6 +1984,14 @@ configstore@^3.0.0:
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
+
+connected-react-router@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-5.0.1.tgz#8379854fad7e027b1e27652c00ad534f8ad244b3"
+  integrity sha512-0QwWYPRGZQ7f284lmqc5kwC4T3iW3zrAH3zzi6uUMzTOxbA+mn38tAgMOoVo9m3pbskvONFtXiajgVkCElE9EQ==
+  dependencies:
+    immutable "^3.8.1"
+    seamless-immutable "^7.1.3"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2100,6 +2120,14 @@ cross-env@^5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
+
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  integrity sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
 
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2441,6 +2469,14 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -2966,6 +3002,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
+escape-string-applescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-applescript/-/escape-string-applescript-2.0.0.tgz#760bca838668e408fe5ee52ce42caf7cb46c5273"
+  integrity sha1-dgvKg4Zo5Aj+XuUs5CyvfLRsUnM=
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -3227,6 +3268,17 @@ execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.2.2.tgz#e2ead472c2c31aad6f73f1ac956eef45e12320cb"
+  integrity sha1-4urUcsLDGq1vc/GslW7vReEjIMs=
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -3272,12 +3324,6 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
 express-history-api-fallback@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/express-history-api-fallback/-/express-history-api-fallback-2.2.1.tgz#3a2ad27f7bebc90fc533d110d7c6d83097bcd057"
-
-express-ws@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/express-ws/-/express-ws-4.0.0.tgz#dabd8dc974516418902a41fe6e30ed949b4d36c4"
-  dependencies:
-    ws "^5.2.0"
 
 express@^4.13.3:
   version "4.16.4"
@@ -3815,6 +3861,18 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "http://registry.npmjs.org/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -4154,27 +4212,22 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.3:
+ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
-immutable@^3.7.4:
+immutable@^3.7.4, immutable@^3.8.1:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 immutable@~3.7.4:
   version "3.7.6"
   resolved "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
-
-import-from@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
-  dependencies:
-    resolve-from "^3.0.0"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -5315,7 +5368,7 @@ lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   dependencies:
@@ -5576,6 +5629,15 @@ moo@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
 
+mount-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mount-point/-/mount-point-3.0.0.tgz#665cb9edebe80d110e658db56c31d0aef51a8f97"
+  integrity sha1-Zly57evoDREOZY21bDHQrvUaj5c=
+  dependencies:
+    "@sindresorhus/df" "^1.0.1"
+    pify "^2.3.0"
+    pinkie-promise "^2.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5783,7 +5845,7 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@^0.7.6, node-pty@^0.7.8:
+node-pty@^0.7.8:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.8.tgz#9ed2f01f84263acc96982876e734aa75490bf3d8"
   dependencies:
@@ -5859,6 +5921,13 @@ npm-path@^2.0.2, npm-path@^2.0.3:
   resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
   dependencies:
     which "^1.2.10"
+
+npm-run-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+  integrity sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=
+  dependencies:
+    path-key "^1.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -6164,9 +6233,10 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
-p-map@^1.1.1:
+p-map@^1.1.1, p-map@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -6286,6 +6356,11 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-key@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
+  integrity sha1-XVPVeAGWRsDWiADbThRua9wqx68=
+
 path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
@@ -6318,6 +6393,13 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
+
 pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
@@ -6340,7 +6422,7 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-pify@^2.0.0, pify@^2.3.0:
+pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -6348,7 +6430,7 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
-pinkie-promise@^2.0.0:
+pinkie-promise@^2.0.0, pinkie-promise@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
   dependencies:
@@ -6695,7 +6777,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.12.1, prettier@^1.14.2, prettier@^1.14.3:
+prettier@^1.12.1, prettier@^1.14.3:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
 
@@ -7371,15 +7453,7 @@ react-router-dom@^4.2.2:
     react-router "^4.3.1"
     warning "^4.0.1"
 
-react-router-redux@5.0.0-alpha.9:
-  version "5.0.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz#825431516e0e6f1fd93b8807f6bd595e23ec3d10"
-  dependencies:
-    history "^4.7.2"
-    prop-types "^15.6.0"
-    react-router "^4.2.0"
-
-react-router@^4.2.0, react-router@^4.3.1:
+react-router@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
   dependencies:
@@ -7640,14 +7714,15 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-"rekit-core@file:../rekit/packages/rekit-core":
+rekit-core@^2.0.0:
   version "2.3.4"
+  resolved "https://registry.yarnpkg.com/rekit-core/-/rekit-core-2.3.4.tgz#015ff37ead09ec69a9d00abaeaebb02fc06b6cff"
+  integrity sha512-vHeKAk1nYHTu+b3CkcmtAoogpfCii9PgnnB5h09eZsy1vnXPF3jMYrORWujYovm/IPTDSu4e1ET13/HM+qah6g==
   dependencies:
     babel-generator "^6.23.0"
     babel-traverse "^6.23.1"
     babel-types "^6.23.0"
     babylon "^6.15.0"
-    chokidar "^2.0.4"
     colors "^1.1.2"
     diff "^3.2.0"
     docdash "^0.4.0"
@@ -7658,19 +7733,17 @@ regjsparser@^0.1.4:
     npm-run "^4.1.0"
     prettier "^1.12.1"
     shelljs "^0.8.0"
+    trash "^4.2.1"
 
-"rekit-studio@file:../rekit-studio":
-  version "3.0.0"
+rekit-studio@^3.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/rekit-studio/-/rekit-studio-2.4.1.tgz#a53db65ed655a04066877877837b4d5f4f412d0a"
+  integrity sha512-IFedcKPuD5AIMMSdJ8HXAutiyQNbzYVJU87iphko21QtxpY1/MZcNWEyi6hhQT1YtNa3txRoOwhSi3P0TtmdrQ==
   dependencies:
-    argparse "^1.0.10"
     body-parser "^1.18.2"
-    compression "^1.7.3"
-    express-ws "^4.0.0"
-    import-from "^2.1.0"
     lodash "^4.17.10"
-    node-pty "^0.7.6"
     package-json "^4.0.1"
-    prettier "^1.14.2"
+    prettier "^1.12.1"
     shelljs "^0.8.2"
     socket.io "^2.0.1"
     watchpack "^1.3.1"
@@ -7846,6 +7919,13 @@ rst-selector-parser@^2.2.3:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
 
+run-applescript@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-3.2.0.tgz#73fb34ce85d3de8076d511ea767c30d4fdfc918b"
+  integrity sha512-Ep0RsvAjnRcBX1p5vogbaBdAGu/8j/ewpvGqnQYunnLd9SM0vWcPJewPKNnWFggf0hF0pwIgwV5XK7qQ7UZ8Qg==
+  dependencies:
+    execa "^0.10.0"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -7916,6 +7996,11 @@ schema-utils@^0.3.0:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
   dependencies:
     ajv "^5.0.0"
+
+seamless-immutable@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
+  integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -8708,6 +8793,21 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
+trash@^4.2.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/trash/-/trash-4.3.0.tgz#6ebeecdea4d666b06e389b47d135ea88e1de5075"
+  integrity sha512-f36TKwIaBiXm63xSrn8OTNghg5CYHBsFVJvcObMo76LRpgariuRi2CqXQHw1VzfeximD0igdGaonOG6N760BtQ==
+  dependencies:
+    escape-string-applescript "^2.0.0"
+    fs-extra "^0.30.0"
+    globby "^7.1.1"
+    p-map "^1.2.0"
+    p-try "^1.0.0"
+    pify "^3.0.0"
+    run-applescript "^3.0.0"
+    uuid "^3.1.0"
+    xdg-trashdir "^2.1.1"
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -8904,6 +9004,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
+  dependencies:
+    os-homedir "^1.0.0"
+
 utf8-byte-length@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
@@ -8936,7 +9043,7 @@ uuid@^2.0.2:
   version "2.0.3"
   resolved "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -9150,7 +9257,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@1, which@^1.2.10, which@^1.2.12, which@^1.2.14, which@^1.2.8, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
@@ -9215,21 +9322,33 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  dependencies:
-    async-limiter "~1.0.0"
-
 ws@~6.1.0:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
   dependencies:
     async-limiter "~1.0.0"
 
+xdg-basedir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
+  integrity sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=
+  dependencies:
+    os-homedir "^1.0.0"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+xdg-trashdir@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/xdg-trashdir/-/xdg-trashdir-2.1.1.tgz#59a60aaf8e6f9240c1daed9a0944b2f514c27d8e"
+  integrity sha512-KcVhPaOu2ZurYNHSRTf1+ZHORkTZGCQ+u0JHN17QixRISJq4pXOnjt/lQcehvtHL5QAKhSzKgyjrcNnPdkPBHA==
+  dependencies:
+    "@sindresorhus/df" "^2.1.0"
+    mount-point "^3.0.0"
+    pify "^2.2.0"
+    user-home "^2.0.0"
+    xdg-basedir "^2.0.0"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
react-router-redux is deprecated and connected-react-router recommended as a replacement.

 (Closes supnate/rekit#167)